### PR TITLE
Update Slack SSL Fingerprint

### DIFF
--- a/slackbot/slackbot.ino
+++ b/slackbot/slackbot.ino
@@ -16,7 +16,7 @@
 #include <ArduinoJson.h>
 #include <Adafruit_NeoPixel.h>
 
-#define SLACK_SSL_FINGERPRINT "AB F0 5B A9 1A E0 AE 5F CE 32 2E 7C 66 67 49 EC DD 6D 6A 38" // If Slack changes their SSL fingerprint, you would need to update this
+#define SLACK_SSL_FINGERPRINT "AC 95 5A 58 B8 4E 0B CD B3 97 D2 88 68 F5 CA C1 0A 81 E3 6E" // If Slack changes their SSL fingerprint, you would need to update this
 #define SLACK_BOT_TOKEN "put-your-slack-token-here" // Get token by creating new bot integration at https://my.slack.com/services/new/bot 
 #define WIFI_SSID       "wifi-name"
 #define WIFI_PASSWORD   "wifi-password"


### PR DESCRIPTION
I've updated the fingerprint with the latest for Slack.  Working as of Apr 15, 2017.